### PR TITLE
Disable MouseTweaks wheel tweak

### DIFF
--- a/timezones/00_eternity/config/MouseTweaks.cfg
+++ b/timezones/00_eternity/config/MouseTweaks.cfg
@@ -1,5 +1,5 @@
 #Mon Mar 16 21:31:25 PDT 2015
-WheelTweak=1
+WheelTweak=0
 LMBTweakWithoutItem=1
 RMBTweak=1
 LMBTweakWithItem=1


### PR DESCRIPTION
MouseTweak's wheel functionality conflicts with NEI's. It's a well-known fact since RR2 era.