### PR TITLE
Fixes Potion and Enchantment ID Conflicts

### DIFF
--- a/timezones/00_eternity/config/Sanguimancy.cfg
+++ b/timezones/00_eternity/config/Sanguimancy.cfg
@@ -23,9 +23,9 @@ balancing {
 ##########################################################################################################
 
 features {
-    I:addHeartPotionID=100
+    I:addHeartPotionID=116
     B:messageWhenCorruptionEffect=true
-    I:removeHeartPotionID=101
+    I:removeHeartPotionID=117
     I:soulNetworkDimensionID=42
 }
 

--- a/timezones/00_eternity/config/aura.cfg
+++ b/timezones/00_eternity/config/aura.cfg
@@ -1,0 +1,96 @@
+# Configuration file
+
+general {
+    #  [default: true]
+    B:"Give Encyclopedia Aura automatically"=true
+
+    # Keep in mind that this translates power/second to RF/tick. [range: 0.0 ~ 1.0, default: 0.75]
+    S:"Power -> RF conversion factor"=0.75
+
+    # Blue Enchant ID [range: 1 ~ 128, default: 114]
+    I:enchantBlue=119
+
+    # Green Enchant ID [range: 1 ~ 128, default: 113]
+    I:enchantGreen=118
+
+    # Orange Enchant ID [range: 1 ~ 128, default: 111]
+    I:enchantOrange=116
+
+    # Red Enchant ID [range: 1 ~ 128, default: 110]
+    I:enchantRed=115
+
+    # Violet Enchant ID [range: 1 ~ 128, default: 115]
+    I:enchantViolet=120
+
+    # Yellow Enchant ID [range: 1 ~ 128, default: 112]
+    I:enchantYellow=117
+
+    # HIGHLY RECOMENDED TO KEEP ON. Disabling this will lead to erratic rendering behavior. [default: true]
+    B:overrideMaxParticleLimit=true
+
+    # Blue Potion ID [range: 1 ~ 128, default: 97]
+    I:potionBlue=132
+
+    # Green Potion ID [range: 1 ~ 128, default: 96]
+    I:potionGreen=131
+
+    # Orange Potion ID [range: 1 ~ 128, default: 94]
+    I:potionOrange=129
+
+    # Red Potion ID [range: 1 ~ 128, default: 93]
+    I:potionRed=128
+
+    # Violet Potion ID [range: 1 ~ 128, default: 98]
+    I:potionViolet=133
+
+    # Yellow Potion ID [range: 1 ~ 128, default: 95]
+    I:potionYellow=130
+
+    #  [range: 1 ~ 2147483647, default: 20]
+    I:pumpArrowDuration=20
+
+    #  [range: 1 ~ 2147483647, default: 1000]
+    I:pumpArrowSpeed=1000
+
+    #  [range: 1 ~ 2147483647, default: 1]
+    I:pumpBurningDuration=1
+
+    #  [range: 1 ~ 2147483647, default: 300]
+    I:pumpBurningSpeed=300
+
+    #  [range: 1 ~ 2147483647, default: 90]
+    I:pumpEggDuration=90
+
+    #  [range: 1 ~ 2147483647, default: 100]
+    I:pumpEggSpeed=100
+
+    #  [range: 1 ~ 2147483647, default: 2]
+    I:pumpFallDuration=2
+
+    #  [range: 1 ~ 2147483647, default: 250]
+    I:pumpFallSpeed=250
+
+    #  [range: 1 ~ 2147483647, default: 180]
+    I:pumpGlowstoneDuration=180
+
+    #  [range: 1 ~ 2147483647, default: 750]
+    I:pumpGlowstoneSpeed=750
+
+    #  [range: 1 ~ 2147483647, default: 10]
+    I:pumpRedstoneDuration=10
+
+    #  [range: 1 ~ 2147483647, default: 1500]
+    I:pumpRedstoneSpeed=1500
+
+    #  [range: 1 ~ 2147483647, default: 10]
+    I:pumpSnowballDuration=10
+
+    #  [range: 1 ~ 2147483647, default: 400]
+    I:pumpSnowballSpeed=400
+
+    #  [range: 1 ~ 2147483647, default: 30]
+    I:pumpTorchDuration=30
+
+    #  [range: 1 ~ 2147483647, default: 750]
+    I:pumpTorchSpeed=750
+}

--- a/timezones/00_eternity/config/redgear/brewcraft.cfg
+++ b/timezones/00_eternity/config/redgear/brewcraft.cfg
@@ -145,17 +145,17 @@ plugins {
 
 "potion effect ids" {
     # Must be over 20. Must also be lowered if you have disabled the potion list expansion.
-    I:"'Angelic' Effect ID"=40
-    I:"'Combustion' Effect ID"=42
-    I:"'Eternal Flame' Effect ID"=46
-    I:"'Fire Eater' Effect ID"=47
-    I:"'Fireproof' Effect ID"=45
-    I:"'Flight' Effect ID"=41
-    I:"'Frozen' Effect ID"=44
-    I:"'Immunity' Effect ID"=43
-    I:"'Poison' Effect ID"=48
-    I:"'Regeneration' Effect ID"=50
-    I:"'Wither' Effect ID"=49
+    I:"'Angelic' Effect ID"=118
+    I:"'Combustion' Effect ID"=120
+    I:"'Eternal Flame' Effect ID"=124
+    I:"'Fire Eater' Effect ID"=125
+    I:"'Fireproof' Effect ID"=123
+    I:"'Flight' Effect ID"=119
+    I:"'Frozen' Effect ID"=122
+    I:"'Immunity' Effect ID"=121
+    I:"'Poison' Effect ID"=126
+    I:"'Regeneration' Effect ID"=128
+    I:"'Wither' Effect ID"=127
 }
 
 


### PR DESCRIPTION
I'm sure there might be some other conflicts that I didn't catch, but I fixed everything I could find:
- Sanguimancy's AddHeart and RemoveHeart were overriding Blood Magic's Drowning and Haste
- All of Brewcraft's Potion Effects were overriding Witchery
- Added the default Aura Cascade config since it isn't already included
    - Changed Potion IDs to resolve conflicts with Botania
    - Changed Enchantment IDs to resolve conflicts with Blue Power