### PR TITLE
INpureCore Additions

### DIFF
--- a/timezones/00_eternity/config/INpureProjects/custom_nei_filters/BCAdditions.js
+++ b/timezones/00_eternity/config/INpureProjects/custom_nei_filters/BCAdditions.js
@@ -1,0 +1,5 @@
+if (FML.isModLoaded("bcadditions") && BCAdditions_enabled){
+    NEI.override("bcadditions:ironCanister", [0]);
+    NEI.override("bcadditions:goldCanister", [0]);
+    NEI.override("bcadditions:diamondCanister", [0]);
+}

--- a/timezones/00_eternity/config/INpureProjects/custom_nei_filters/BiblioWoods.js
+++ b/timezones/00_eternity/config/INpureProjects/custom_nei_filters/BiblioWoods.js
@@ -1,0 +1,19 @@
+if (FML.isModLoaded("BiblioWoodsBoP") && BWBoP_enabled){
+    NEI.override("BiblioWoodsBoP:*", [0]);
+}
+
+if (FML.isModLoaded("BiblioWoodsForestry") && BWForestry_enabled){
+    NEI.override("BiblioWoodsForestry:*", [0]);
+    NEI.hide("BiblioWoodsForestry:BiblioWoodFst*2");
+    NEI.hide("BiblioWoodsForestry:BiblioWoodFstcase1");
+    NEI.hide("BiblioWoodsForestry:BiblioWoodSeat2");
+    NEI.hide("BiblioWoodsForestry:BiblioWoodMapFrame2");
+    NEI.hide("BiblioWoodsForestry:BiblioWoodFancySign2");
+    NEI.hide("BiblioWoodsForestry:BiblioWoodFancyWorkbench2");
+    NEI.hide("BiblioWoodsForestry:BiblioWoodClock2");
+    NEI.hide("BiblioWoodsForestry:BiblioWoodPaintingT*b");
+}
+
+if (FML.isModLoaded("BiblioWoodsNatura") && BWNatura_enabled){
+    NEI.override("BiblioWoodsNatura:*", [0]);
+}

--- a/timezones/00_eternity/config/INpureProjects/custom_nei_filters/ExtraCells.js
+++ b/timezones/00_eternity/config/INpureProjects/custom_nei_filters/ExtraCells.js
@@ -1,0 +1,3 @@
+if (FML.isModLoaded("extracells") && ExtraCells_enabled){
+    NEI.override("extracells:pattern.fluid", [0]);
+}

--- a/timezones/00_eternity/config/INpureProjects/custom_nei_filters/Gendustry.js
+++ b/timezones/00_eternity/config/INpureProjects/custom_nei_filters/Gendustry.js
@@ -1,0 +1,3 @@
+if (FML.isModLoaded("gendustry") && Gendustry_enabled){
+    NEI.hide("gendustry:GeneSample");
+}

--- a/timezones/00_eternity/config/INpureProjects/custom_nei_filters/IC2.js
+++ b/timezones/00_eternity/config/INpureProjects/custom_nei_filters/IC2.js
@@ -1,0 +1,3 @@
+if (FML.isModLoaded("IC2") && IC2_enabled){
+    NEI.override("IC2:itemFluidCell", [0]);
+}

--- a/timezones/00_eternity/config/INpureProjects/custom_nei_filters/PressurePipes.js
+++ b/timezones/00_eternity/config/INpureProjects/custom_nei_filters/PressurePipes.js
@@ -1,0 +1,3 @@
+if (FML.isModLoaded("pressure") && PressurePipes_enabled){
+    NEI.override("pressure:Canister", [0]);
+}

--- a/timezones/00_eternity/config/INpureProjects/custom_nei_filters/custom_nei_filters.cfg
+++ b/timezones/00_eternity/config/INpureProjects/custom_nei_filters/custom_nei_filters.cfg
@@ -5,6 +5,9 @@ scripting {
     S:BCAdditions_enabled=true
     S:Bibliocraft_enabled=true
     S:BuildCraft_enabled=true
+    S:BWBoP_enabled=true
+    S:BWForestry_enabled=true
+    S:BWNatura_enabled=true
     S:ExtraCells_enabled=true
     S:ExtraUtilities_enabled=true
     S:ForgeMicroblock_enabled=true

--- a/timezones/00_eternity/config/INpureProjects/custom_nei_filters/custom_nei_filters.cfg
+++ b/timezones/00_eternity/config/INpureProjects/custom_nei_filters/custom_nei_filters.cfg
@@ -2,12 +2,16 @@
 
 scripting {
     S:AE2_enabled=true
+    S:BCAdditions_enabled=true
     S:Bibliocraft_enabled=true
     S:BuildCraft_enabled=true
+    S:ExtraCells_enabled=true
     S:ExtraUtilities_enabled=true
     S:ForgeMicroblock_enabled=true
+    S:Gendustry_enabled=true
     S:MFR_enabled=true
     S:Mekanism_enabled=true
+    S:PressurePipes_enabled=true
     S:Tcon_enabled=true
     S:ThermalExpansion_enabled=true
     S:vanilla_enabled=true

--- a/timezones/00_eternity/config/INpureProjects/custom_nei_filters/custom_nei_filters.cfg
+++ b/timezones/00_eternity/config/INpureProjects/custom_nei_filters/custom_nei_filters.cfg
@@ -9,6 +9,7 @@ scripting {
     S:ExtraUtilities_enabled=true
     S:ForgeMicroblock_enabled=true
     S:Gendustry_enabled=true
+    S:IC2_enabled=true
     S:MFR_enabled=true
     S:Mekanism_enabled=true
     S:PressurePipes_enabled=true

--- a/timezones/00_eternity/config/INpureProjects/custom_nei_filters/nei_filters.toc
+++ b/timezones/00_eternity/config/INpureProjects/custom_nei_filters/nei_filters.toc
@@ -2,7 +2,7 @@
 ## Author: denoflionsx
 ## Version: 1.0
 ## Bootstrap: Bootstrap.js
-## Saved Variables: vanilla_enabled, ThermalExpansion_enabled, Mekanism_enabled, ForgeMicroblock_enabled, ExtraUtilities_enabled, BuildCraft_enabled, Bibliocraft_enabled, AE2_enabled, Tcon_enabled, MFR_enabled, BCAdditions_enabled, PressurePipes_enabled, ExtraCells_enabled, Gendustry_enabled, IC2_enabled
+## Saved Variables: vanilla_enabled, ThermalExpansion_enabled, Mekanism_enabled, ForgeMicroblock_enabled, ExtraUtilities_enabled, BuildCraft_enabled, Bibliocraft_enabled, AE2_enabled, Tcon_enabled, MFR_enabled, BCAdditions_enabled, PressurePipes_enabled, ExtraCells_enabled, Gendustry_enabled, IC2_enabled, BWBoP_enabled, BWForestry_enabled, BWNatura_enabled
 vanilla.js
 ThermalExpansion.js
 Mekanism.js
@@ -18,3 +18,4 @@ PressurePipes.js
 ExtraCells.js
 Gendustry.js
 IC2.js
+BiblioWoods.js

--- a/timezones/00_eternity/config/INpureProjects/custom_nei_filters/nei_filters.toc
+++ b/timezones/00_eternity/config/INpureProjects/custom_nei_filters/nei_filters.toc
@@ -2,7 +2,7 @@
 ## Author: denoflionsx
 ## Version: 1.0
 ## Bootstrap: Bootstrap.js
-## Saved Variables: vanilla_enabled, ThermalExpansion_enabled, Mekanism_enabled, ForgeMicroblock_enabled, ExtraUtilities_enabled, BuildCraft_enabled, Bibliocraft_enabled, AE2_enabled, Tcon_enabled, MFR_enabled, BCAdditions_enabled, PressurePipes_enabled, ExtraCells_enabled, Gendustry_enabled
+## Saved Variables: vanilla_enabled, ThermalExpansion_enabled, Mekanism_enabled, ForgeMicroblock_enabled, ExtraUtilities_enabled, BuildCraft_enabled, Bibliocraft_enabled, AE2_enabled, Tcon_enabled, MFR_enabled, BCAdditions_enabled, PressurePipes_enabled, ExtraCells_enabled, Gendustry_enabled, IC2_enabled
 vanilla.js
 ThermalExpansion.js
 Mekanism.js
@@ -17,3 +17,4 @@ BCAdditions.js
 PressurePipes.js
 ExtraCells.js
 Gendustry.js
+IC2.js

--- a/timezones/00_eternity/config/INpureProjects/custom_nei_filters/nei_filters.toc
+++ b/timezones/00_eternity/config/INpureProjects/custom_nei_filters/nei_filters.toc
@@ -2,7 +2,7 @@
 ## Author: denoflionsx
 ## Version: 1.0
 ## Bootstrap: Bootstrap.js
-## Saved Variables: vanilla_enabled, ThermalExpansion_enabled, Mekanism_enabled, ForgeMicroblock_enabled, ExtraUtilities_enabled, BuildCraft_enabled, Bibliocraft_enabled, AE2_enabled, Tcon_enabled, MFR_enabled
+## Saved Variables: vanilla_enabled, ThermalExpansion_enabled, Mekanism_enabled, ForgeMicroblock_enabled, ExtraUtilities_enabled, BuildCraft_enabled, Bibliocraft_enabled, AE2_enabled, Tcon_enabled, MFR_enabled, BCAdditions_enabled, PressurePipes_enabled, ExtraCells_enabled, Gendustry_enabled
 vanilla.js
 ThermalExpansion.js
 Mekanism.js
@@ -13,3 +13,7 @@ Bibliocraft.js
 AppliedEnergistics2.js
 Tcon.js
 MFR.js
+BCAdditions.js
+PressurePipes.js
+ExtraCells.js
+Gendustry.js


### PR DESCRIPTION
Hides prefilled containers from NEI:

- **BuildCraft Additions:** Iron Canister, Gold Canister, Diamond Canister
- **ExtraCells:** ME Fluid Pattern [WIP]
- **Pressure Pipes:** Canister
- **Gendustry:** Gene Sample
- **IC2:** Universal Cells

Also hides all but one of every BiblioWoods item for each of the three BiblioWoods mods.