### PR TITLE
Fix Unstable Ingot crafting

### DIFF
--- a/config/GanysMods/ganyssurface.cfg
+++ b/config/GanysMods/ganyssurface.cfg
@@ -29,7 +29,7 @@ general {
     B:"Enable No Recipe Conflict for Crafting Tables"=true
 
     # You'll need to turn this off to craft Extra Utilities's Unstable Ingots
-    B:"Enable No Recipe Conflict for only the vanilla Crafting Tables"=true
+    B:"Enable No Recipe Conflict for only the vanilla Crafting Tables"=false
     B:"Enable Poop Throwing"=true
     B:"Enable Prismarine stuff"=true
     B:"Enable Rain Detector"=true


### PR DESCRIPTION
Unstable Ingots can't be crafted in the vanilla crafting table when this config option is turned on because Gany's Surface modifies the crafting table. This is intended to interact with another mod (No More Recipe Conflicts) that isn't in RR3 so turning it off shouldn't have any actually effect other than making unstable ingots craftable again.