### PR TITLE
Fix conflicting Biome/Potion IDs

### DIFF
--- a/config/ForbiddenMagic.cfg
+++ b/config/ForbiddenMagic.cfg
@@ -80,7 +80,7 @@ general {
 
 
 potions {
-    I:"Blood Seal"=70
+    I:"Blood Seal"=125
 }
 
 
@@ -97,5 +97,3 @@ silly {
     # What is this?  I don't even...
     B:"Spork of Doom"=false
 }
-
-

--- a/config/Thaumcraft.cfg
+++ b/config/Thaumcraft.cfg
@@ -8,13 +8,13 @@
 
 biomes {
     # Eerie biome id
-    I:biome_eerie=121
+    I:biome_eerie=118
 
     # Eldritch Lands biome id
     I:biome_eldritch=122
 
     # Magical Forest biome id
-    I:biome_magical_forest=123
+    I:biome_magical_forest=119
 
     # Taint biome id
     I:biome_taint=120
@@ -207,5 +207,3 @@ world_regeneration {
     B:taint=false
     B:trees=false
 }
-
-

--- a/config/biomesoplenty/ids.cfg
+++ b/config/biomesoplenty/ids.cfg
@@ -18,7 +18,7 @@
     I:"Coral Reef ID"=98
     I:"Corrupted Sands ID"=104
     I:"Crag ID"=52
-    I:"Dead Forest ID"=92
+    I:"Dead Forest ID"=117
     I:"Dead Swamp ID"=54
     I:"Deciduous Forest ID"=55
     I:"Dense Forest ID"=184
@@ -46,7 +46,7 @@
     I:"Maple Woods ID"=72
     I:"Marsh ID"=73
     I:"Meadow Forest ID"=202
-    I:"Meadow ID"=74
+    I:"Meadow ID"=116
     I:"Moor ID"=75
     I:"Mountain ID"=76
     I:"Mystic Grove ID"=77
@@ -116,5 +116,3 @@
     I:"Paralysis Potion ID"=117
     I:"Possession Potion ID"=118
 }
-
-


### PR DESCRIPTION
Found and fixed Potion and Biome ID conflicts. I did my best to change the losing sides of the conflicts to have minimal if any impact on players' worlds.

| Potion ID | Conflict Winner | Conflict Loser |
| --- | --- | --- |
| 70 | Witchery: Feel No Pain | Forbidden Magic: Blood Seal |

| Biome ID | Conflict Winner | Conflict Loser |
| --- | --- | --- |
| 74 | Dimensional World: Mining Biome | Biomes o Plenty: Meadow |
| 92 | BoP: Thicket | BoP: Dead Forest |
| 121 | BoP: Spectral Garden | Thaumcraft: Eerie |
| 123 | BoP: Dry River | Thaumcraft: Magical Forest |

I found these with the [Anti ID Conflict mod](http://www.minecraftforum.net/forums/mapping-and-modding/minecraft-mods/2387300-say-no-to-id-conflicts-install-anti-id-conflict). I arbitrarily picked IDs in the first empty gap I found, so if you want them changed to something else just let me know (or you could close this PR and do it yourself I suppose).
